### PR TITLE
OP-1084: Pagination fix in Searchers in invoice module

### DIFF
--- a/src/components/BillEventsSearcher.js
+++ b/src/components/BillEventsSearcher.js
@@ -47,9 +47,15 @@ const BillEventsSearcher = ({
     const queryParams = Object.keys(filters)
       .filter((f) => !!filters[f]["filter"])
       .map((f) => filters[f]["filter"]);
-    pageSize && queryParams.push(`first: ${pageSize}`);
-    beforeCursor && queryParams.push(`before: "${beforeCursor}"`);
-    afterCursor && queryParams.push(`after: "${afterCursor}"`);
+    !beforeCursor && !afterCursor && queryParams.push(`first: ${pageSize}`);
+    if (afterCursor) {
+      queryParams.push(`after: "${afterCursor}"`);
+      queryParams.push(`first: ${pageSize}`);
+    }
+    if (beforeCursor) {
+      queryParams.push(`before: "${beforeCursor}"`);
+      queryParams.push(`last: ${pageSize}`);
+    }
     orderBy && queryParams.push(`orderBy: ["${orderBy}"]`);
     setQueryParams(queryParams);
     return queryParams;

--- a/src/components/BillPaymentsSearcher.js
+++ b/src/components/BillPaymentsSearcher.js
@@ -99,9 +99,15 @@ const BillPaymentsSearcher = ({
     const queryParams = Object.keys(filters)
       .filter((f) => !!filters[f]["filter"])
       .map((f) => filters[f]["filter"]);
-    pageSize && queryParams.push(`first: ${pageSize}`);
-    beforeCursor && queryParams.push(`before: "${beforeCursor}"`);
-    afterCursor && queryParams.push(`after: "${afterCursor}"`);
+    !beforeCursor && !afterCursor && queryParams.push(`first: ${pageSize}`);
+    if (afterCursor) {
+      queryParams.push(`after: "${afterCursor}"`);
+      queryParams.push(`first: ${pageSize}`);
+    }
+    if (beforeCursor) {
+      queryParams.push(`before: "${beforeCursor}"`);
+      queryParams.push(`last: ${pageSize}`);
+    }
     orderBy && queryParams.push(`orderBy: ["${orderBy}"]`);
     setQueryParams(queryParams);
     return queryParams;

--- a/src/components/InvoiceEventsSearcher.js
+++ b/src/components/InvoiceEventsSearcher.js
@@ -47,9 +47,15 @@ const InvoiceEventsSearcher = ({
     const queryParams = Object.keys(filters)
       .filter((f) => !!filters[f]["filter"])
       .map((f) => filters[f]["filter"]);
-    pageSize && queryParams.push(`first: ${pageSize}`);
-    beforeCursor && queryParams.push(`before: "${beforeCursor}"`);
-    afterCursor && queryParams.push(`after: "${afterCursor}"`);
+    !beforeCursor && !afterCursor && queryParams.push(`first: ${pageSize}`);
+    if (afterCursor) {
+      queryParams.push(`after: "${afterCursor}"`);
+      queryParams.push(`first: ${pageSize}`);
+    }
+    if (beforeCursor) {
+      queryParams.push(`before: "${beforeCursor}"`);
+      queryParams.push(`last: ${pageSize}`);
+    }
     orderBy && queryParams.push(`orderBy: ["${orderBy}"]`);
     setQueryParams(queryParams);
     return queryParams;

--- a/src/components/InvoicePaymentsSearcher.js
+++ b/src/components/InvoicePaymentsSearcher.js
@@ -99,9 +99,15 @@ const InvoicePaymentsSearcher = ({
     const queryParams = Object.keys(filters)
       .filter((f) => !!filters[f]["filter"])
       .map((f) => filters[f]["filter"]);
-    pageSize && queryParams.push(`first: ${pageSize}`);
-    beforeCursor && queryParams.push(`before: "${beforeCursor}"`);
-    afterCursor && queryParams.push(`after: "${afterCursor}"`);
+    !beforeCursor && !afterCursor && queryParams.push(`first: ${pageSize}`);
+    if (afterCursor) {
+      queryParams.push(`after: "${afterCursor}"`);
+      queryParams.push(`first: ${pageSize}`);
+    }
+    if (beforeCursor) {
+      queryParams.push(`before: "${beforeCursor}"`);
+      queryParams.push(`last: ${pageSize}`);
+    }
     orderBy && queryParams.push(`orderBy: ["${orderBy}"]`);
     setQueryParams(queryParams);
     return queryParams;


### PR DESCRIPTION
[OP-1084](https://openimis.atlassian.net/browse/OP-1084)

Changes:

- Pagination fix in **_BillPaymentsSearcher.js_**, **_BillEventsSearcher.js_**, **_InvoiceEventsSearcher.js_** and **_InvoicePaymentsSearcher.js_**. **Last** and **first** parameters had to be adjusted to the existing logic. Rest of the searchers in this module do not have a specified **filtersToQueryParams** function, which means they are using this one from core (it was fixed before).

[OP-1084]: https://openimis.atlassian.net/browse/OP-1084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ