### PR TITLE
OP-1468: fix dialog when export fails

### DIFF
--- a/src/components/BillSearcher.js
+++ b/src/components/BillSearcher.js
@@ -3,7 +3,7 @@ import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
 
-import { IconButton, Tooltip, Button, Dialog, DialogActions, DialogTitle } from "@material-ui/core";
+import { IconButton, Tooltip, Button, Dialog, DialogActions, DialogTitle, DialogContent } from "@material-ui/core";
 import EditIcon from "@material-ui/icons/Edit";
 import DeleteIcon from "@material-ui/icons/Delete";
 
@@ -72,13 +72,17 @@ const BillSearcher = ({
   }, [confirmed]);
 
   useEffect(() => {
-    setFailedExport(true);
+    if (errorBillsExport) {
+      setFailedExport(true);
+    }
   }, [errorBillsExport]);
 
   useEffect(() => {
     if (billsExport) {
       downloadExport(billsExport, "bill_export.csv")();
     }
+
+    return setFailedExport(false);
   }, [billsExport]);
 
   useEffect(() => {
@@ -250,12 +254,15 @@ const BillSearcher = ({
           "status": "Status",
         }}
       />
-
       {failedExport && (
-        <Dialog fullWidth maxWidth="sm">
-          <DialogTitle>{errorBillsExport}</DialogTitle>
+        <Dialog open={failedExport} fullWidth maxWidth="sm">
+          <DialogTitle>{errorBillsExport?.message}</DialogTitle>
+          <DialogContent>
+            <strong>{`${errorBillsExport?.code}: `}</strong>
+            {errorBillsExport?.detail}
+          </DialogContent>
           <DialogActions>
-            <Button onClick={setFailedExport(false)} variant="contained">
+            <Button onClick={() => setFailedExport(false)} color="primary" variant="contained">
               {formatMessage(intl, "invoice", "ok")}
             </Button>
           </DialogActions>


### PR DESCRIPTION
[OP-1486](https://openimis.atlassian.net/browse/OP-1468)

Changes:
- Improve error handling for export failures. Currently, a pop-up message is displayed from the backend.

[OP-1486]: https://openimis.atlassian.net/browse/OP-1486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ