### PR TITLE
OP-1854: use billPayment instead of paymentInvoice

### DIFF
--- a/src/components/BillPaymentsFilter.js
+++ b/src/components/BillPaymentsFilter.js
@@ -94,7 +94,15 @@ const BillPaymentsFilter = ({ classes, filters, onChangeFilters }) => {
           label="billPayment.fees"
           min={0}
           value={filterValue("fees")}
-          onChange={onChangeFilter("fees")}
+          onChange={(fee) =>
+            onChangeFilters([
+              {
+                id: "fees",
+                value: !fee ? null : fee,
+                filter: fee ? `fees: "${parseFloat(fee)}"` : null,
+              },
+            ])
+          }
         />
       </Grid>
       <Grid item xs={2} className={classes.item}>
@@ -103,7 +111,15 @@ const BillPaymentsFilter = ({ classes, filters, onChangeFilters }) => {
           label="billPayment.amountReceived"
           min={0}
           value={filterValue("amountReceived")}
-          onChange={onChangeFilter("amountReceived")}
+          onChange={(amountReceived) =>
+            onChangeFilters([
+              {
+                id: "amountReceived",
+                value: !amountReceived ? null : amountReceived,
+                filter: amountReceived ? `amountReceived: "${parseFloat(amountReceived)}"` : null,
+              },
+            ])
+          }
         />
       </Grid>
       <Grid item xs={2} className={classes.item}>

--- a/src/components/BillPaymentsFilter.js
+++ b/src/components/BillPaymentsFilter.js
@@ -5,7 +5,7 @@ import _debounce from "lodash/debounce";
 import { Grid } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 
-import { withModulesManager, formatMessage, TextInput, NumberInput, PublishedComponent } from "@openimis/fe-core";
+import { withModulesManager, TextInput, NumberInput, PublishedComponent } from "@openimis/fe-core";
 import { CONTAINS_LOOKUP, DEFUALT_DEBOUNCE_TIME, STARTS_WITH_LOOKUP } from "../constants";
 
 const styles = (theme) => ({

--- a/src/components/BillPaymentsFilter.js
+++ b/src/components/BillPaymentsFilter.js
@@ -7,7 +7,6 @@ import { withTheme, withStyles } from "@material-ui/core/styles";
 
 import { withModulesManager, formatMessage, TextInput, NumberInput, PublishedComponent } from "@openimis/fe-core";
 import { CONTAINS_LOOKUP, DEFUALT_DEBOUNCE_TIME, STARTS_WITH_LOOKUP } from "../constants";
-import PaymentInvoiceStatusPicker from "../pickers/PaymentInvoiceStatusPicker";
 
 const styles = (theme) => ({
   form: {
@@ -18,7 +17,7 @@ const styles = (theme) => ({
   },
 });
 
-const BillPaymentsFilter = ({ intl, classes, filters, onChangeFilters }) => {
+const BillPaymentsFilter = ({ classes, filters, onChangeFilters }) => {
   const debouncedOnChangeFilters = _debounce(onChangeFilters, DEFUALT_DEBOUNCE_TIME);
 
   const filterValue = (filterName) => filters?.[filterName]?.value;
@@ -58,26 +57,9 @@ const BillPaymentsFilter = ({ intl, classes, filters, onChangeFilters }) => {
   return (
     <Grid container className={classes.form}>
       <Grid item xs={2} className={classes.item}>
-        <PaymentInvoiceStatusPicker
-          label="paymentInvoice.reconciliationStatus.label"
-          withNull
-          nullLabel={formatMessage(intl, "invoice", "any")}
-          value={filterValue("reconciliationStatus")}
-          onChange={(value) =>
-            onChangeFilters([
-              {
-                id: "reconciliationStatus",
-                value: value,
-                filter: `reconciliationStatus: "${value}"`,
-              },
-            ])
-          }
-        />
-      </Grid>
-      <Grid item xs={2} className={classes.item}>
         <TextInput
           module="invoice"
-          label="paymentInvoice.codeExt"
+          label="billPayment.codeExt"
           value={filterTextFieldValue("codeExt")}
           onChange={onChangeStringFilter("codeExt", CONTAINS_LOOKUP)}
         />
@@ -85,7 +67,7 @@ const BillPaymentsFilter = ({ intl, classes, filters, onChangeFilters }) => {
       <Grid item xs={2} className={classes.item}>
         <TextInput
           module="invoice"
-          label="paymentInvoice.label"
+          label="billPayment.label"
           value={filterTextFieldValue("label")}
           onChange={onChangeStringFilter("label", STARTS_WITH_LOOKUP)}
         />
@@ -93,7 +75,7 @@ const BillPaymentsFilter = ({ intl, classes, filters, onChangeFilters }) => {
       <Grid item xs={2} className={classes.item}>
         <TextInput
           module="invoice"
-          label="paymentInvoice.codeTp"
+          label="billPayment.codeTp"
           value={filterTextFieldValue("codeTp")}
           onChange={onChangeStringFilter("codeTp", CONTAINS_LOOKUP)}
         />
@@ -101,7 +83,7 @@ const BillPaymentsFilter = ({ intl, classes, filters, onChangeFilters }) => {
       <Grid item xs={2} className={classes.item}>
         <TextInput
           module="invoice"
-          label="paymentInvoice.codeReceipt"
+          label="billPayment.codeReceipt"
           value={filterTextFieldValue("codeReceipt")}
           onChange={onChangeStringFilter("codeReceipt", CONTAINS_LOOKUP)}
         />
@@ -109,7 +91,7 @@ const BillPaymentsFilter = ({ intl, classes, filters, onChangeFilters }) => {
       <Grid item xs={2} className={classes.item}>
         <NumberInput
           module="invoice"
-          label="paymentInvoice.fees"
+          label="billPayment.fees"
           min={0}
           value={filterValue("fees")}
           onChange={onChangeFilter("fees")}
@@ -118,7 +100,7 @@ const BillPaymentsFilter = ({ intl, classes, filters, onChangeFilters }) => {
       <Grid item xs={2} className={classes.item}>
         <NumberInput
           module="invoice"
-          label="paymentInvoice.amountReceived"
+          label="billPayment.amountReceived"
           min={0}
           value={filterValue("amountReceived")}
           onChange={onChangeFilter("amountReceived")}
@@ -128,7 +110,7 @@ const BillPaymentsFilter = ({ intl, classes, filters, onChangeFilters }) => {
         <PublishedComponent
           pubRef="core.DatePicker"
           module="invoice"
-          label="paymentInvoice.datePayment"
+          label="billPayment.datePayment"
           value={filterValue("datePayment")}
           onChange={onChangeStringFilter("datePayment")}
         />
@@ -136,17 +118,9 @@ const BillPaymentsFilter = ({ intl, classes, filters, onChangeFilters }) => {
       <Grid item xs={2} className={classes.item}>
         <TextInput
           module="invoice"
-          label="paymentInvoice.paymentOrigin"
+          label="billPayment.paymentOrigin"
           value={filterTextFieldValue("paymentOrigin")}
           onChange={onChangeStringFilter("paymentOrigin", CONTAINS_LOOKUP)}
-        />
-      </Grid>
-      <Grid item xs={2} className={classes.item}>
-        <TextInput
-          module="invoice"
-          label="paymentInvoice.payerRef"
-          value={filterTextFieldValue("payerRef")}
-          onChange={onChangeStringFilter("payerRef", CONTAINS_LOOKUP)}
         />
       </Grid>
     </Grid>

--- a/src/components/BillPaymentsSearcher.js
+++ b/src/components/BillPaymentsSearcher.js
@@ -132,7 +132,7 @@ const BillPaymentsSearcher = ({
       (billPayment) => billPayment.fees,
       (billPayment) => billPayment.amountReceived,
       (billPayment) =>
-        !!billPayment.datePayment
+        billPayment.datePayment
           ? formatDateFromISO(modulesManager, intl, billPayment.datePayment)
           : EMPTY_STRING,
       (billPayment) => billPayment.paymentOrigin,

--- a/src/components/BillPaymentsSearcher.js
+++ b/src/components/BillPaymentsSearcher.js
@@ -1,5 +1,11 @@
 import React, { useRef, useEffect, useState } from "react";
+import { bindActionCreators } from "redux";
+import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
+
+import { IconButton, Tooltip } from "@material-ui/core";
+import DeleteIcon from "@material-ui/icons/Delete";
+
 import {
   formatMessage,
   formatMessageWithValues,
@@ -8,20 +14,15 @@ import {
   withModulesManager,
   coreConfirm,
 } from "@openimis/fe-core";
-import { bindActionCreators } from "redux";
-import { connect } from "react-redux";
-import { fetchPaymentInvoices, deletePaymentInvoice } from "../actions";
+import { fetchBillPayments, deleteBillPayment } from "../actions";
 import {
   DEFAULT_PAGE_SIZE,
   EMPTY_STRING,
   RIGHT_BILL_PAYMENT_DELETE,
   ROWS_PER_PAGE_OPTIONS,
 } from "../constants";
-import BillPaymentsFilter from "./BillPaymentsFilter";
-import PaymentInvoiceStatusPicker from "../pickers/PaymentInvoiceStatusPicker"
-import DeleteIcon from "@material-ui/icons/Delete";
-import { IconButton, Tooltip } from "@material-ui/core";
 import { ACTION_TYPE } from "../reducer";
+import BillPaymentsFilter from "./BillPaymentsFilter";
 
 const BillPaymentsSearcher = ({
   intl,
@@ -29,38 +30,37 @@ const BillPaymentsSearcher = ({
   rights,
   bill,
   setConfirmedAction,
-  deletePaymentInvoice,
   submittingMutation,
   mutation,
   coreConfirm,
   confirmed,
-  fetchPaymentInvoices,
-  fetchingPaymentInvoices,
-  fetchedPaymentInvoices,
-  errorPaymentInvoices,
-  paymentInvoices,
-  paymentInvoicesPageInfo,
-  paymentInvoicesTotalCount,
+  fetchBillPayments,
+  fetchingBillPayments,
+  fetchedBillPayments,
+  errorBillPayments,
+  billPayments,
+  billPaymentsPageInfo,
+  billPaymentsTotalCount,
 }) => {
   const [queryParams, setQueryParams] = useState([]);
-  const [paymentInvoiceToDelete, setPaymentInvoiceToDelete] = useState(null);
-  const [deletedPaymentInvoiceUuids, setDeletedPaymentInvoiceUuids] = useState([]);
+  const [billPaymentToDelete, setBillPaymentToDelete] = useState(null);
+  const [deletedBillPaymentUuids, setDeletedBillPaymentUuids] = useState([]);
   const prevSubmittingMutationRef = useRef();
 
-  useEffect(() => paymentInvoiceToDelete && openDeletePaymentInvoiceConfirmDialog(), [paymentInvoiceToDelete]);
+  useEffect(() => billPaymentToDelete && openDeleteBillPaymentConfirmDialog(), [billPaymentToDelete]);
 
   useEffect(() => {
-    if (paymentInvoiceToDelete && confirmed) {
-      setDeletedPaymentInvoiceUuids([...deletedPaymentInvoiceUuids, paymentInvoiceToDelete.id]);
+    if (billPaymentToDelete && confirmed) {
+      setDeletedBillPaymentUuids([...deletedBillPaymentUuids, billPaymentToDelete.id]);
     }
-    paymentInvoiceToDelete && confirmed !== null && setPaymentInvoiceToDelete(null);
+    billPaymentToDelete && confirmed !== null && setBillPaymentToDelete(null);
   }, [confirmed]);
 
   useEffect(() => {
     if (
       prevSubmittingMutationRef.current &&
       !submittingMutation &&
-      [ACTION_TYPE.CREATE_PAYMENT_INVOICE_WITH_DETAIL, ACTION_TYPE.UPDATE_BILL_PAYMENT].includes(mutation?.actionType)
+      [ACTION_TYPE.CREATE_BILL_PAYMENT, ACTION_TYPE.UPDATE_BILL_PAYMENT].includes(mutation?.actionType)
     ) {
       refetch();
     }
@@ -70,28 +70,28 @@ const BillPaymentsSearcher = ({
     prevSubmittingMutationRef.current = submittingMutation;
   });
 
-  const deletePaymentInvoiceCallback = () =>
-    deletePaymentInvoice(
-      paymentInvoiceToDelete,
-      formatMessageWithValues(intl, "invoice", "paymentInvoice.delete.mutationLabel", {
-        paymentInvoiceLabel: paymentInvoiceToDelete?.label,
-        code: bill?.code,
+  const deleteBillPaymentCallback = () =>
+    deleteBillPayment(
+      billPaymentToDelete,
+      formatMessageWithValues(intl, "invoice", "billPayment.delete.mutationLabel", {
+        billPaymentLabel: billPaymentToDelete?.label,
+        billCode: bill?.code,
       }),
     );
 
-  const openDeletePaymentInvoiceConfirmDialog = () => {
-    setConfirmedAction(() => deletePaymentInvoiceCallback);
+  const openDeleteBillPaymentConfirmDialog = () => {
+    setConfirmedAction(() => deleteBillPaymentCallback);
     coreConfirm(
-      formatMessageWithValues(intl, "invoice", "paymentInvoice.delete.confirm.title", {
-        paymentInvoiceLabel: paymentInvoiceToDelete?.label,
+      formatMessageWithValues(intl, "invoice", "billPayment.delete.confirm.title", {
+        billPaymentLabel: billPaymentToDelete?.label,
       }),
-      formatMessage(intl, "invoice", "paymentInvoice.delete.confirm.message"),
+      formatMessage(intl, "invoice", "billPayment.delete.confirm.message"),
     );
   };
 
-  const onDelete = (paymentInvoice) => setPaymentInvoiceToDelete(paymentInvoice);
+  const onDelete = (billPayment) => setBillPaymentToDelete(billPayment);
 
-  const fetch = (params) => fetchPaymentInvoices(params);
+  const fetch = (params) => fetchBillPayments(params);
 
   const refetch = () => fetch(queryParams);
 
@@ -114,41 +114,36 @@ const BillPaymentsSearcher = ({
   };
 
   const headers = () => [
-    "paymentInvoice.reconciliationStatus.label",
-    "paymentInvoice.codeExt",
-    "paymentInvoice.label",
-    "paymentInvoice.codeTp",
-    "paymentInvoice.codeReceipt",
-    "paymentInvoice.fees",
-    "paymentInvoice.amountReceived",
-    "paymentInvoice.datePayment",
-    "paymentInvoice.paymentOrigin",
-    "paymentInvoice.payerRef",
+    "billPayment.codeExt",
+    "billPayment.label",
+    "billPayment.codeTp",
+    "billPayment.codeReceipt",
+    "billPayment.fees",
+    "billPayment.amountReceived",
+    "billPayment.datePayment",
   ];
 
   const itemFormatters = () => {
     const formatters = [
-      (paymentInvoice) => <PaymentInvoiceStatusPicker value={paymentInvoice?.reconciliationStatus} readOnly />,
-      (paymentInvoice) => paymentInvoice.codeExt,
-      (paymentInvoice) => paymentInvoice.label,
-      (paymentInvoice) => paymentInvoice.codeTp,
-      (paymentInvoice) => paymentInvoice.codeReceipt,
-      (paymentInvoice) => paymentInvoice.fees,
-      (paymentInvoice) => paymentInvoice.amountReceived,
-      (paymentInvoice) =>
-        !!paymentInvoice.datePayment
-          ? formatDateFromISO(modulesManager, intl, paymentInvoice.datePayment)
+      (billPayment) => billPayment.codeExt,
+      (billPayment) => billPayment.label,
+      (billPayment) => billPayment.codeTp,
+      (billPayment) => billPayment.codeReceipt,
+      (billPayment) => billPayment.fees,
+      (billPayment) => billPayment.amountReceived,
+      (billPayment) =>
+        !!billPayment.datePayment
+          ? formatDateFromISO(modulesManager, intl, billPayment.datePayment)
           : EMPTY_STRING,
-      (paymentInvoice) => paymentInvoice.paymentOrigin,
-      (paymentInvoice) => paymentInvoice.payerRef,
+      (billPayment) => billPayment.paymentOrigin,
     ];
 
     if (rights.includes(RIGHT_BILL_PAYMENT_DELETE)) {
-      formatters.push((paymentInvoice) => (
+      formatters.push((billPayment) => (
         <Tooltip title={formatMessage(intl, "invoice", "deleteButtonTooltip")}>
           <IconButton
-            onClick={() => onDelete(paymentInvoice)}
-            disabled={deletedPaymentInvoiceUuids.includes(paymentInvoice.id)}
+            onClick={() => onDelete(billPayment)}
+            disabled={deletedBillPaymentUuids.includes(billPayment.id)}
           >
             <DeleteIcon />
           </IconButton>
@@ -159,7 +154,6 @@ const BillPaymentsSearcher = ({
   };
 
   const sorts = () => [
-    ["reconciliationStatus", true],
     ["codeExt", true],
     ["label", true],
     ["codeTp", true],
@@ -168,13 +162,12 @@ const BillPaymentsSearcher = ({
     ["amountReceived", true],
     ["datePayment", true],
     ["paymentOrigin", true],
-    ["payerRef", true],
   ];
 
   const defaultFilters = () => ({
     subjectIds: {
       value: bill?.id,
-      filter: `subjectIds: ["${bill?.id}"]`,
+      filter: `id: "${bill?.id}"`,
     },
     isDeleted: {
       value: false,
@@ -182,7 +175,7 @@ const BillPaymentsSearcher = ({
     },
   });
 
-  const isRowDisabled = (_, paymentInvoice) => deletedPaymentInvoiceUuids.includes(paymentInvoice.id);
+  const isRowDisabled = (_, billPayment) => deletedBillPaymentUuids.includes(billPayment.id);
 
   return (
     !!bill?.id && (
@@ -190,13 +183,13 @@ const BillPaymentsSearcher = ({
         module="bill"
         FilterPane={BillPaymentsFilter}
         fetch={fetch}
-        items={paymentInvoices}
-        itemsPageInfo={paymentInvoicesPageInfo}
-        fetchingItems={fetchingPaymentInvoices}
-        fetchedItems={fetchedPaymentInvoices}
-        errorItems={errorPaymentInvoices}
-        tableTitle={formatMessageWithValues(intl, "invoice", "paymentInvoices.searcherResultsTitle", {
-          paymentInvoicesTotalCount,
+        items={billPayments}
+        itemsPageInfo={billPaymentsPageInfo}
+        fetchingItems={fetchingBillPayments}
+        fetchedItems={fetchedBillPayments}
+        errorItems={errorBillPayments}
+        tableTitle={formatMessageWithValues(intl, "invoice", "billPayments.searcherResultsTitle", {
+          billPaymentsTotalCount,
         })}
         filtersToQueryParams={filtersToQueryParams}
         headers={headers}
@@ -214,12 +207,12 @@ const BillPaymentsSearcher = ({
 };
 
 const mapStateToProps = (state) => ({
-  fetchingPaymentInvoices: state.invoice.fetchingPaymentInvoices,
-  fetchedPaymentInvoices: state.invoice.fetchedPaymentInvoices,
-  errorPaymentInvoices: state.invoice.errorPaymentInvoices,
-  paymentInvoices: state.invoice.paymentInvoices,
-  paymentInvoicesPageInfo: state.invoice.paymentInvoicesPageInfo,
-  paymentInvoicesTotalCount: state.invoice.paymentInvoicesTotalCount,
+  fetchingBillPayments: state.invoice.fetchingBillPayments,
+  fetchedBillPayments: state.invoice.fetchedBillPayments,
+  errorBillPayments: state.invoice.errorBillPayments,
+  billPayments: state.invoice.billPayments,
+  billPaymentsPageInfo: state.invoice.billPaymentsPageInfo,
+  billPaymentsTotalCount: state.invoice.billPaymentsTotalCount,
   submittingMutation: state.invoice.submittingMutation,
   mutation: state.invoice.mutation,
   confirmed: state.core.confirmed,
@@ -228,8 +221,8 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = (dispatch) => {
   return bindActionCreators(
     {
-      fetchPaymentInvoices,
-      deletePaymentInvoice,
+      fetchBillPayments,
+      deleteBillPayment,
       coreConfirm
     },
     dispatch,


### PR DESCRIPTION
[OP-1854](https://openimis.atlassian.net/browse/OP-1854)

Changes:
- Use _billPayment_ query instead if _paymentInvoice_.
- All references to paymentInvoice are replaced by billPayment.
- Enhance filter functionality to accommodate decimal values for fees and amountReceived parameters.

[OP-1854]: https://openimis.atlassian.net/browse/OP-1854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ