### PR TITLE
fix: fix the filter states on the Invoices page

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -204,7 +204,7 @@ const formatPaymentInvoiceGQL = (payment, subjectId, subjectType) =>
   `
     ${!!payment.id ? `id: "${payment.id}"` : ""}
     ${!!subjectId ? `subjectId: "${subjectId}"` : ""}
-    ${!!subjectType ? `subjectTypeName "${subjectType}"` : ""}
+    ${!!subjectType ? `subjectType: "${subjectType}"` : ""}
     ${!!payment.status ? `status: ${payment.status}` : ""}
     ${!!payment.reconciliationStatus ? `reconciliationStatus: ${payment.reconciliationStatus}` : ""}
     ${!!payment.codeExt ? `codeExt: "${payment.codeExt}"` : ""}

--- a/src/components/InvoiceEventsFilter.jsx
+++ b/src/components/InvoiceEventsFilter.jsx
@@ -50,7 +50,15 @@ const InvoiceEventsFilter = ({ intl, filters, onChangeFilters }) => {
             withNull
             nullLabel={formatMessage(intl, "invoice", "any")}
             value={filterValue("eventType")}
-            onChange={onChangeStringFilter("eventType")}
+            onChange={(value) =>
+              onChangeFilters([
+                {
+                  id: "eventType",
+                  value: value,
+                  filter: `eventType: A_${value}`,
+                },
+              ])
+            }
           />
         </Grid>
         <Grid size={GRID_RESPONSIVE_STANDARD} className="item">

--- a/src/components/InvoiceFilter.jsx
+++ b/src/components/InvoiceFilter.jsx
@@ -105,7 +105,13 @@ const InvoiceFilter = ({ intl, filters, onChangeFilters }) => {
             withNull
             nullLabel={formatMessage(intl, "invoice", "any")}
             value={filterValue("status")}
-            onChange={onChangeStringFilter("status")}
+            onChange={(value) => onChangeFilters([
+              {
+                id: "status",
+                value: value,
+                filter: value ? `status: A_${value}` : null,
+              },
+            ])}
           />
         </Grid>
         <Grid size={GRID_RESPONSIVE_STANDARD} className="item">

--- a/src/components/InvoicePaymentsFilter.jsx
+++ b/src/components/InvoicePaymentsFilter.jsx
@@ -65,7 +65,7 @@ const InvoicePaymentsFilter = ({ intl, filters, onChangeFilters }) => {
                 {
                   id: "reconciliationStatus",
                   value: value,
-                  filter: `reconciliationStatus: "${value}"`,
+                  filter: `reconciliationStatus: A_${value}`,
                 },
               ])
             }

--- a/src/components/InvoiceSearcher.jsx
+++ b/src/components/InvoiceSearcher.jsx
@@ -48,6 +48,7 @@ const InvoiceSearcher = ({
   invoices,
   invoicesPageInfo,
   invoicesTotalCount,
+  cacheFiltersKey
 }) => {
   const [invoiceToDelete, setInvoiceToDelete] = useState(null);
   const [deletedInvoiceUuids, setDeletedInvoiceUuids] = useState([]);
@@ -175,6 +176,7 @@ const InvoiceSearcher = ({
   return (
     <Searcher
       module="invoice"
+      cacheFiltersKey={cacheFiltersKey}
       FilterPane={InvoiceFilter}
       fetch={fetch}
       items={invoices}

--- a/src/pages/InvoicesPage.jsx
+++ b/src/pages/InvoicesPage.jsx
@@ -23,7 +23,7 @@ const InvoicesPage = ({ intl, rights }) => {
       {rights.includes(RIGHT_INVOICE_SEARCH) && (
         <div className="page">
           <Helmet title={formatMessage(intl, "invoice", "invoices.pageTitle")} />
-          <InvoiceSearcher rights={rights} />
+          <InvoiceSearcher cacheFiltersKey="invoiceInvoicesPageFiltersCache" rights={rights} />
         </div>
       )}
     </StyledInvoicesPage>

--- a/src/pickers/SubjectTypePicker.jsx
+++ b/src/pickers/SubjectTypePicker.jsx
@@ -14,16 +14,15 @@ const SubjectTypePicker = ({
   nullLabel = null,
   withLabel = true,
 }) => {
-  const options = SUBJECT_TYPE_OPTIONS;
-
-  useEffect(() => {
-    if (withNull) {
-      options.unshift({
-        value: null,
-        label: nullLabel || formatMessage(intl, "invoice", "emptyLabel"),
-      });
-    }
-  }, []);
+  const options = [
+    ...(withNull
+      ? [{
+          value: null,
+          label: nullLabel || formatMessage(intl, "invoice", "emptyLabel"),
+        }]
+      : []),
+    ...SUBJECT_TYPE_OPTIONS,
+  ];
 
   return (
     <SelectInput

--- a/src/pickers/ThirdpartyTypePicker.jsx
+++ b/src/pickers/ThirdpartyTypePicker.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { SelectInput } from "@openimis/fe-core";
 import { formatMessage } from "@openimis/fe-core";
 import { injectIntl } from "react-intl";
@@ -14,16 +14,17 @@ const ThirdpartyTypePicker = ({
   nullLabel = null,
   withLabel = true,
 }) => {
-  const options = THIRDPARTY_TYPE_OPTIONS;
-
-  useEffect(() => {
-    if (withNull) {
-      options.unshift({
-        value: null,
-        label: nullLabel || formatMessage(intl, "invoice", "emptyLabel"),
-      });
-    }
-  }, []);
+  const options = [
+    ...(withNull
+      ? [
+          {
+            value: null,
+            label: nullLabel || formatMessage(intl, "invoice", "emptyLabel"),
+          },
+        ]
+      : []),
+    ...THIRDPARTY_TYPE_OPTIONS,
+  ];
 
   return (
     <SelectInput


### PR DESCRIPTION
#Thank you for your contribution to openIMIS!
#Please complete the sections below. Anything in comments is guidance and can be deleted.

# Description

## Summary of Changes

This PR fixes two issues in the invoice search/filtering workflow:

1. **Preserve invoice search filters during navigation**

   * Invoice list filters are now kept in session while navigating between the invoice list and invoice details.
   * Users can apply filters, open an invoice from the results, and return to the list without losing the previously applied filters.
   * Filters are only cleared when the user explicitly resets them.

2. **Prevent duplicated “Any” options in filter selectors**

   * Fixed an issue where the `"Any"` option was being duplicated in filter dropdowns each time users navigated back and forth to the invoice list.
   * The dropdown options are now generated without mutating the original options arrays, preventing repeated insertion of the null/empty option.


# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify
- [x] Enhancement

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [x] External reference https://openimis.atlassian.net/browse/OP-3066

## Demo

<img width="1860" height="997" alt="Capture d’écran du 2026-06-03 16-41-11" src="https://github.com/user-attachments/assets/a2f7f3d3-56e8-4979-b474-26962e3ff9bf" />

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
