### PR TITLE
fix(invoice): map subjectType/thirdpartyType to Filter in fetchInvoices

### DIFF
--- a/src/components/InvoiceFilter.jsx
+++ b/src/components/InvoiceFilter.jsx
@@ -61,8 +61,8 @@ const InvoiceFilter = ({ intl, filters, onChangeFilters }) => {
             label="invoice.subject"
             withNull
             nullLabel={formatMessage(intl, "invoice", "any")}
-            value={filterValue("subjectType")}
-            onChange={onChangeStringFilter("subjectType")}
+            value={filterValue("subjectTypeFilter")}
+            onChange={onChangeStringFilter("subjectTypeFilter")}
           />
         </Grid>
         <Grid size={GRID_RESPONSIVE_STANDARD} className="item">
@@ -70,8 +70,8 @@ const InvoiceFilter = ({ intl, filters, onChangeFilters }) => {
             label="invoice.thirdparty"
             withNull
             nullLabel={formatMessage(intl, "invoice", "any")}
-            value={filterValue("thirdpartyType")}
-            onChange={onChangeStringFilter("thirdpartyType")}
+            value={filterValue("thirdpartyTypeFilter")}
+            onChange={onChangeStringFilter("thirdpartyTypeFilter")}
           />
         </Grid>
         <Grid size={GRID_RESPONSIVE_STANDARD} className="item">


### PR DESCRIPTION
## Description

**Problem:** The frontend sends `subjectType` and `thirdpartyType` with business names (e.g., "contract", "insuree") to the Invoice GraphQL endpoint, but the backend expects ContentType IDs.

**Solution:** Transform `subjectType` → `subjectTypeFilter` and `thirdpartyType` → `thirdpartyTypeFilter` in `fetchInvoices` to match the new backend filters.

## Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [x] Requires  https://github.com/openimis/openimis-be-invoice_py/pull/80
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

[Capture vidéo du 12-07-2026 11:27:08.webm](https://github.com/user-attachments/assets/6bf36f03-60d4-402b-a3c6-070a4bb846f2)
[Capture vidéo du 12-07-2026 11:25:49.webm](https://github.com/user-attachments/assets/02488d39-1a41-4f8b-8571-e118775a7c75)

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
